### PR TITLE
Openssl3 fixes

### DIFF
--- a/.github/workflows/build-test-mac.yml
+++ b/.github/workflows/build-test-mac.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: configure
       run: |
-        cmake -S . -B build -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@1.1 -DCMAKE_BUILD_TYPE=Release ..
+        cmake -S . -B build -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@3.4 -DCMAKE_BUILD_TYPE=Release ..
 
     - name: build
       working-directory: build
@@ -32,7 +32,7 @@ jobs:
     - name: list artifacts
       run: ls -R
 
-    - uses: actions/upload-artifact@master
+    - uses: actions/upload-artifact@v4
       with:
         name: lcxx-tests-mac
         path: |
@@ -45,9 +45,9 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: lcxx-tests-mac
 

--- a/.github/workflows/build-test-ubuntu.yml
+++ b/.github/workflows/build-test-ubuntu.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -36,7 +36,7 @@ jobs:
       working-directory: build
       run: cmake --build .
 
-    - uses: actions/upload-artifact@master
+    - uses: actions/upload-artifact@v4
       with:
         name: lcxx-tests-ubuntu
         path: |
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Get latest GCC (libstdc++ required)
       uses: egor-tensin/setup-gcc@v1
@@ -58,7 +58,7 @@ jobs:
         version: 11
         platform: x64
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: lcxx-tests-ubuntu
 

--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -30,7 +30,7 @@ jobs:
       working-directory: build
       run: cmake --build . --config Release 
 
-    - uses: actions/upload-artifact@master
+    - uses: actions/upload-artifact@v4
       with:
         name: lcxx-tests-windows
         path: |
@@ -43,12 +43,12 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # - name: install OpenSSL
     #   run: choco install openssl
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: lcxx-tests-windows
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ SET(CMAKE_DISABLE_SOURCE_CHANGES OFF) #keys are generated in the source tree by 
 SET(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 
 option(LCXX_GENERATE_KEYS "Whether RSA key files should be generated during build time." OFF)
+option(LCXX_NLOHMANN_JSON_CMAKE_FETCH "Whether licensecxx tries to download its own version of nlohmann::json" ON)
 
 include(cmake/get_version.cmake)
 pull_version()
@@ -16,7 +17,11 @@ set(VERSION_DIR ${CMAKE_BINARY_DIR}/version)
 configure_file("scripts/version.hpp.in" "${CMAKE_BINARY_DIR}/version/lcxx/version.hpp")
 
 include(${PROJECT_SOURCE_DIR}/cmake/key_targets.cmake)
-include(${PROJECT_SOURCE_DIR}/cmake/get_nlohmann_json.cmake)
+
+if(LCXX_NLOHMANN_JSON_CMAKE_FETCH) 
+	cmake_policy(SET CMP0135 NEW)
+	include(${PROJECT_SOURCE_DIR}/cmake/get_nlohmann_json.cmake)
+endif() 
 
 add_subdirectory(${PROJECT_SOURCE_DIR}/modules)
 

--- a/docs/Sphinx/source/How-to-use-it.rst
+++ b/docs/Sphinx/source/How-to-use-it.rst
@@ -25,6 +25,8 @@ This project is supposed to be used as a library addition to your software. Lice
 
 The ``lcxx::identifiers`` library is optional to produce/verify identifying hash codes of the target machine.
 
+Note that `LCXX_NLOHMANN_JSON_CMAKE_FETCH` can be explicitly turned off to prevent LCXX from downloading Nlohmann::Json using CMake Fetchcontent.
+
 Generate a license
 ------------------
 

--- a/modules/crypto/include/lcxx/hash.hpp
+++ b/modules/crypto/include/lcxx/hash.hpp
@@ -4,28 +4,19 @@
 #include <span>
 #include <string>
 
-#include <openssl/md5.h>
-#include <openssl/sha.h>
+#include <openssl/evp.h>
 
 namespace lcxx::hash {
 
-    using md5_hash_t    = std::array< std::byte, MD5_DIGEST_LENGTH >;
-    using sha512_hash_t = std::array< std::byte, SHA512_DIGEST_LENGTH >;
+    enum class error {
+        ok,
+        ctx_allocation_failure,
+        digest_init_failure,
+        digest_update_failure,
+        digest_finalization_failure,
+    };
 
-    /**
-     * @brief calculates an MD5 hashsum over an input string
-     *
-     * @param input the string that will be digested
-     * @return md5_hash_t the MD5 hash in byte-array form
-     */
-    auto md5( std::string const & input ) -> md5_hash_t;
-    auto md5( std::span< const std::byte > const input ) -> md5_hash_t;
-    template < typename T >
-    requires( sizeof( T ) == 1 ) auto md5( std::span< T > const input ) -> md5_hash_t
-    {
-        return md5(
-            std::span< const std::byte >{ reinterpret_cast< std::byte const * >( input.data() ), input.size() } );
-    }
+    using sha512_hash_t = std::array< std::byte, 64 >;
 
     /**
      * @brief calculates a SHA512 hashsum over an input string
@@ -33,10 +24,11 @@ namespace lcxx::hash {
      * @param input the string that will be digested
      * @return sha512_hash_t the SHA512 hash in byte-array form
      */
-    auto sha512( std::string const & input ) -> sha512_hash_t;
-    auto sha512( std::span< const std::byte > const input ) -> sha512_hash_t;
+    auto sha512( std::string const & input ) -> std::pair< sha512_hash_t, error >;
+    auto sha512( std::span< const std::byte > const input ) -> std::pair< sha512_hash_t, error >;
     template < typename T >
-    requires( sizeof( T ) == 1 ) auto sha512( std::span< T > const input ) -> sha512_hash_t
+        requires( sizeof( T ) == 1 )
+    auto sha512( std::span< T > const input ) -> std::pair< sha512_hash_t, error >
     {
         return sha512(
             std::span< const std::byte >{ reinterpret_cast< std::byte const * >( input.data() ), input.size() } );

--- a/modules/crypto/include/lcxx/hash.hpp
+++ b/modules/crypto/include/lcxx/hash.hpp
@@ -1,6 +1,7 @@
 #ifndef LCXX__CRYPTO_HASH_HPP__
 #define LCXX__CRYPTO_HASH_HPP__
 
+#include <array>
 #include <span>
 #include <string>
 

--- a/modules/crypto/src/hash.cpp
+++ b/modules/crypto/src/hash.cpp
@@ -2,39 +2,47 @@
 
 #include <array>
 #include <cstddef>
+#include <memory>
+
+namespace {
+    struct mdctx_free {
+        void operator()( EVP_MD_CTX * md_ctx )
+        {
+            if ( md_ctx )
+                EVP_MD_CTX_free( md_ctx );
+        }
+    };
+}  // namespace
 
 namespace lcxx::hash {
 
-    auto md5( std::string const & input ) -> md5_hash_t
-    {
-        std::span< const std::byte > const byte_span = { reinterpret_cast< std::byte const * >( input.data() ),
-                                                         input.size() };
-        return md5( byte_span );
-    }
-
-    auto md5( std::span< const std::byte > const input ) -> md5_hash_t
-    {
-        md5_hash_t hash_buffer;
-        MD5( reinterpret_cast< unsigned char const * >( input.data() ), input.size(),
-             reinterpret_cast< unsigned char * >( hash_buffer.data() ) );
-
-        return hash_buffer;
-    }
-
-    auto sha512( std::string const & input ) -> sha512_hash_t
+    auto sha512( std::string const & input ) -> std::pair< sha512_hash_t, error >
     {
         std::span< const std::byte > const byte_span = { reinterpret_cast< std::byte const * >( input.data() ),
                                                          input.size() };
         return sha512( byte_span );
     }
 
-    auto sha512( std::span< const std::byte > const input ) -> sha512_hash_t
+    auto sha512( std::span< const std::byte > const input ) -> std::pair< sha512_hash_t, error >
     {
         sha512_hash_t hash_buffer;
-        SHA512( reinterpret_cast< unsigned char const * >( input.data() ), input.size(),
-                reinterpret_cast< unsigned char * >( hash_buffer.data() ) );
+        auto          with = [&hash_buffer]( error code ) { return std::make_pair( hash_buffer, code ); };
 
-        return hash_buffer;
+        auto ctx = std::unique_ptr< EVP_MD_CTX, mdctx_free >( EVP_MD_CTX_new(), mdctx_free{} );
+        if ( ctx == nullptr )
+            return with( error::ctx_allocation_failure );
+
+        if ( 1 != EVP_DigestInit_ex( ctx.get(), EVP_sha512(), NULL ) )
+            return with( error::digest_init_failure );
+
+        if ( 1 != EVP_DigestUpdate( ctx.get(), input.data(), input.size() ) )
+            return with( error::digest_update_failure );
+
+        unsigned int len;
+        if ( 1 != EVP_DigestFinal_ex( ctx.get(), reinterpret_cast< unsigned char * >( hash_buffer.data() ), &len ) )
+            return with( error::digest_finalization_failure );
+
+        return with( error::ok );
     }
 
 }  // namespace lcxx::hash

--- a/modules/identifiers/include/lcxx/identifiers/identifier.hpp
+++ b/modules/identifiers/include/lcxx/identifiers/identifier.hpp
@@ -1,13 +1,20 @@
 #ifndef LCXX__IDENTIFIERS_IDENTIFIER_HPP__
 #define LCXX__IDENTIFIERS_IDENTIFIER_HPP__
 
+#include <cstdint>
 #include <string>
 
 namespace lcxx::experimental::identifiers {
 
-    using ident_strat_t = std::int32_t;
+    using ident_strat_t = std::int16_t;
+
+    enum class error {
+        ok,
+        hash_error,
+    };
 
     struct identifier {
+        error         err;
         std::string   hash;
         std::string   source_text;
         ident_strat_t ident_strat;

--- a/modules/identifiers/src/hardware.cpp
+++ b/modules/identifiers/src/hardware.cpp
@@ -26,7 +26,10 @@ namespace lcxx::experimental::identifiers {
 
         if ( strat_active( strategy, hw_ident_strat::all ) ) {
             auto msg = nlohmann::json{ cpu_info }.dump();
-            return { encode::base64( hash::md5( msg ) ), msg };
+            auto [hash, err] = hash::sha512( msg );
+            if ( err != hash::error::ok )
+                return { error::hash_error, {}, msg };
+            return { error::ok, encode::base64( hash ), msg };
         }
 
         if ( strat_active( strategy, hw_ident_strat::cpu ) ) {
@@ -46,7 +49,10 @@ namespace lcxx::experimental::identifiers {
         }
 
         auto msg = info_json.dump();
-        return { encode::base64( hash::md5( msg ) ), msg };
+        auto [hash, err] = hash::sha512( msg );
+        if ( err != hash::error::ok )
+            return { error::hash_error, {}, msg };
+        return { error::ok, encode::base64( hash ), msg };
         // if(strat_active(strategy, hw_ident_strat::gpu) {}
         // if(strat_active(strategy, hw_ident_strat::network) {}
     }

--- a/modules/identifiers/src/os.cpp
+++ b/modules/identifiers/src/os.cpp
@@ -27,8 +27,13 @@ namespace lcxx::experimental::identifiers {
 
         if ( strat_active( strategy, os_ident_strat::all ) ) {
             auto msg = nlohmann::json{ os_info }.dump();
+
+            auto [hash, err] = hash::sha512( msg );
+            if ( err != hash::error::ok )
+                return { error::hash_error, {}, msg };
             return {
-                encode::base64( hash::md5( msg ) ),
+                error::hash_error,
+                encode::base64( hash ),
                 msg,
             };
         }
@@ -61,7 +66,10 @@ namespace lcxx::experimental::identifiers {
         }
 
         auto msg = id_json.dump();
-        return { encode::base64( hash::md5( msg ) ), msg, static_cast< ident_strat_t >( strategy ) };
+        auto [hash, err] = hash::sha512( msg );
+        if ( err != hash::error::ok )
+            return { error::hash_error, {}, msg };
+        return { error::ok, encode::base64( hash ), msg, static_cast< ident_strat_t >( strategy ) };
     }
 
     auto verify( os_ident_strat const strategy, std::string_view const hash ) -> bool

--- a/tests/crypto/hash_test.cpp
+++ b/tests/crypto/hash_test.cpp
@@ -6,9 +6,13 @@
 
 #include <lcxx/hash.hpp>
 
-template < std::ranges::range R > auto str_to_vec( std::string_view const str ) -> R
+template < std::ranges::range R >
+auto str_to_vec( std::string_view const str ) -> R
+    requires( sizeof( std::ranges::range_value_t< R > ) == 1 )
 {
-    auto bytes = str | std::views::transform( []( auto && c ) { return std::ranges::range_value_t< R >{ c }; } );
+    auto bytes = str | std::views::transform( []( auto && c ) {
+                     return *reinterpret_cast< std::ranges::range_value_t< R > const * >( &c );
+                 } );
     return { bytes.begin(), bytes.end() };
 }
 

--- a/tests/crypto/hash_test.cpp
+++ b/tests/crypto/hash_test.cpp
@@ -1,69 +1,69 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <array>
+#include <ranges>
 
 #include <lcxx/hash.hpp>
 
-TEST( Crypto_Tests, MD5_Hash_String_Test )
+template < std::ranges::range R > auto str_to_vec( std::string_view const str ) -> R
 {
-    constexpr auto                        test_string    = "my arbitrary test string";
-    constexpr std::array< std::byte, 16 > reference_hash = {
-        std::byte{ 0xFD }, std::byte{ 0xAD }, std::byte{ 0xC7 }, std::byte{ 0xD1 },
-        std::byte{ 0x83 }, std::byte{ 0x40 }, std::byte{ 0x95 }, std::byte{ 0xEB },
-        std::byte{ 0xB9 }, std::byte{ 0x01 }, std::byte{ 0xC2 }, std::byte{ 0x6F },
-        std::byte{ 0xA7 }, std::byte{ 0xB8 }, std::byte{ 0xF1 }, std::byte{ 0xED },
-    };
-
-    auto md5 = lcxx::hash::md5( test_string );
-    EXPECT_EQ( md5, reference_hash );
+    auto bytes = str | std::views::transform( []( auto && c ) { return std::ranges::range_value_t< R >{ c }; } );
+    return { bytes.begin(), bytes.end() };
 }
 
-TEST( Crypto_Tests, MD5_Hash_Byte_Test )
+template < typename T, std::size_t N >
+auto gen_byte_arr( std::initializer_list< T > const & r ) -> std::array< std::byte, N >
 {
-    std::vector< std::byte > const test_bytes = {
-        std::byte{ 'm' }, std::byte{ 'y' }, std::byte{ ' ' }, std::byte{ 'a' }, std::byte{ 'r' }, std::byte{ 'b' },
-        std::byte{ 'i' }, std::byte{ 't' }, std::byte{ 'r' }, std::byte{ 'a' }, std::byte{ 'r' }, std::byte{ 'y' },
-        std::byte{ ' ' }, std::byte{ 't' }, std::byte{ 'e' }, std::byte{ 's' }, std::byte{ 't' }, std::byte{ ' ' },
-        std::byte{ 's' }, std::byte{ 't' }, std::byte{ 'r' }, std::byte{ 'i' }, std::byte{ 'n' }, std::byte{ 'g' },
-    };
-    constexpr std::array< std::byte, 16 > reference_hash = {
-        std::byte{ 0xFD }, std::byte{ 0xAD }, std::byte{ 0xC7 }, std::byte{ 0xD1 },
-        std::byte{ 0x83 }, std::byte{ 0x40 }, std::byte{ 0x95 }, std::byte{ 0xEB },
-        std::byte{ 0xB9 }, std::byte{ 0x01 }, std::byte{ 0xC2 }, std::byte{ 0x6F },
-        std::byte{ 0xA7 }, std::byte{ 0xB8 }, std::byte{ 0xF1 }, std::byte{ 0xED },
-    };
+    auto bytes = r | std::views::transform( []( auto && c ) { return std::byte{ c }; } );
 
-    auto md5 = lcxx::hash::md5( test_bytes );
-    EXPECT_EQ( md5, reference_hash );
+    std::array< std::byte, N > arr;
+    std::ranges::copy( bytes, arr.begin() );
+    return arr;
 }
 
-TEST( Crypto_Tests, MD5_Hash_Other_Type_Test )
-{
-    std::vector< uint8_t > const test_bytes = {
-        'm', 'y', ' ', 'a', 'r', 'b', 'i', 't', 'r', 'a', 'r', 'y',
-        ' ', 't', 'e', 's', 't', ' ', 's', 't', 'r', 'i', 'n', 'g',
-    };
-    constexpr std::array< std::byte, 16 > reference_hash = {
-        std::byte{ 0xFD }, std::byte{ 0xAD }, std::byte{ 0xC7 }, std::byte{ 0xD1 },
-        std::byte{ 0x83 }, std::byte{ 0x40 }, std::byte{ 0x95 }, std::byte{ 0xEB },
-        std::byte{ 0xB9 }, std::byte{ 0x01 }, std::byte{ 0xC2 }, std::byte{ 0x6F },
-        std::byte{ 0xA7 }, std::byte{ 0xB8 }, std::byte{ 0xF1 }, std::byte{ 0xED },
-    };
+constexpr auto    test_string    = "my arbitrary test string";
+static const auto reference_hash = gen_byte_arr< uint8_t, 64 >( {
+    0xb2, 0xd1, 0xdc, 0x2a, 0xd5, 0x61, 0xc7, 0x2b, 0x68, 0x53, 0x6c, 0xa6, 0x34, 0x5b, 0x2e, 0xd2,
+    0xeb, 0xba, 0x6e, 0x97, 0x2a, 0x0b, 0x71, 0x6c, 0x03, 0xdc, 0x44, 0xc7, 0xaa, 0xcd, 0x02, 0xa7,
+    0x89, 0x9e, 0xc1, 0x7a, 0xca, 0x2a, 0x3d, 0xeb, 0xc2, 0xa5, 0xd5, 0x70, 0xdb, 0xeb, 0x8e, 0x9c,
+    0xd6, 0xbf, 0xa4, 0xe5, 0x19, 0xe5, 0xd0, 0xe6, 0x56, 0xda, 0x06, 0x62, 0xc3, 0x0b, 0xc8, 0x2b,
+} );
 
-    auto md5 = lcxx::hash::md5( std::span< const uint8_t >{ test_bytes.data(), test_bytes.size() } );
-    EXPECT_EQ( md5, reference_hash );
+TEST( Crypto_Tests, SHA512_Hash_String_Test )
+{
+    auto [sha512, err] = lcxx::hash::sha512( test_string );
+    EXPECT_EQ( err, lcxx::hash::error::ok );
+    EXPECT_EQ( sha512, reference_hash );
 }
 
-TEST( Crypto_Tests, MD5_Hash_Test_whitespace )
+TEST( Crypto_Tests, SHA512_Hash_Byte_Test )
+{
+    auto const test_bytes = str_to_vec< std::vector< std::byte > >( test_string );
+    auto [sha512, err]    = lcxx::hash::sha512( test_bytes );
+    EXPECT_EQ( err, lcxx::hash::error::ok );
+    EXPECT_EQ( sha512, reference_hash );
+}
+
+TEST( Crypto_Tests, SHA512_Hash_Other_Type_Test )
+{
+    auto const test_bytes = str_to_vec< std::vector< uint8_t > >( test_string );
+    auto [sha512, err]    = lcxx::hash::sha512( std::span< const uint8_t >{ test_bytes.data(), test_bytes.size() } );
+    EXPECT_EQ( err, lcxx::hash::error::ok );
+    EXPECT_EQ( sha512, reference_hash );
+}
+
+TEST( Crypto_Tests, SHA512_Hash_Test_whitespace )
 {
     constexpr auto                        test_string    = " ";
-    constexpr std::array< std::byte, 16 > reference_hash = {
-        std::byte{ 0x72 }, std::byte{ 0x15 }, std::byte{ 0xEE }, std::byte{ 0x9C },
-        std::byte{ 0x7D }, std::byte{ 0x9D }, std::byte{ 0xC2 }, std::byte{ 0x29 },
-        std::byte{ 0xD2 }, std::byte{ 0x92 }, std::byte{ 0x1A }, std::byte{ 0x40 },
-        std::byte{ 0xE8 }, std::byte{ 0x99 }, std::byte{ 0xEC }, std::byte{ 0x5F },
-    };
+    auto                                  reference_hash = gen_byte_arr< uint8_t, 64 >( {
+        0xf9, 0x0d, 0xdd, 0x77, 0xe4, 0x00, 0xdf, 0xe6, 0xa3, 0xfc, 0xf4, 0x79, 0xb0, 0x0b, 0x1e, 0xe2,
+        0x9e, 0x70, 0x15, 0xc5, 0xbb, 0x8c, 0xd7, 0x0f, 0x5f, 0x15, 0xb4, 0x88, 0x6c, 0xc3, 0x39, 0x27,
+        0x5f, 0xf5, 0x53, 0xfc, 0x8a, 0x05, 0x3f, 0x8d, 0xdc, 0x73, 0x24, 0xf4, 0x51, 0x68, 0xcf, 0xfa,
+        0xf8, 0x1f, 0x8c, 0x3a, 0xc9, 0x39, 0x96, 0xf6, 0x53, 0x6e, 0xef, 0x38, 0xe5, 0xe4, 0x07, 0x68,
+    } );
 
-    auto md5 = lcxx::hash::md5( test_string );
-    EXPECT_EQ( md5, reference_hash );
+     auto [sha512, err] = lcxx::hash::sha512( test_string );
+     EXPECT_EQ( err, lcxx::hash::error::ok );
+     EXPECT_EQ( sha512, reference_hash );
 }


### PR DESCRIPTION
Mostly just bumps OpenSSL from 1.1 to 3.

Additionally also removes the MD5 hashing and replaces it with SHA256. That's a breaking change, but I don't even know if anyone uses this lib.

If that's an issue for someone, speak up lol